### PR TITLE
Feature/scheduled jobs

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,25 @@
+# Golang CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-go/ for more details
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version
+      - image: circleci/golang:1.9
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    #### TEMPLATE_NOTE: go expects specific checkout path representing url
+    #### expecting it in the form of
+    ####   /go/src/github.com/circleci/go-tool
+    ####   /go/src/bitbucket.org/circleci/go-tool
+    working_directory: /go/src/github.com/jcleira/thrall
+    steps:
+      - checkout
+
+      # specify any bash command here prefixed with `run: `
+      - run: go get -v -t -d ./...
+      - run: go test -v ./...

--- a/thrall/repeatable.go
+++ b/thrall/repeatable.go
@@ -1,0 +1,8 @@
+package thrall
+
+// Repeatable defines an interface that should be implemented for that jobs
+// that would need to be re-executed repeatedly, the Repeat() func may be used
+// to control the repetition number.
+type Repeateable interface {
+	Repeat() bool
+}

--- a/thrall/runnable.go
+++ b/thrall/runnable.go
@@ -1,7 +1,8 @@
 package thrall
 
-// Runnable is thrall's Job interface, that should be implemented by the
-// package's users to create jobs tha thrall would be able to run.
+// Runnable is thrall's main Job interface, the Run() func is some work that
+// need to be performed. It should be implemented by the package's users to
+// create jobs to be run using thrall.
 type Runnable interface {
 	Run() error
 }

--- a/thrall/scheduleable.go
+++ b/thrall/scheduleable.go
@@ -1,0 +1,10 @@
+package thrall
+
+import "time"
+
+// Scheduleable defines an interface that should be implemented for that jobs
+// that would need to be executed on given time, the Schedule() func returns
+// a time.Time that would be the execution time for that job.
+type Scheduleable interface {
+	Schedule() time.Time
+}

--- a/thrall/worker_pool_test.go
+++ b/thrall/worker_pool_test.go
@@ -2,19 +2,69 @@ package thrall
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
 
+type testJob struct {
+	Executed bool
+}
+
+func (tj *testJob) Run() error {
+	tj.Executed = true
+	return nil
+}
+
+type scheduleableJob struct {
+	testJob
+}
+
+func (sj *scheduleableJob) Schedule() time.Time {
+	return time.Now().Add(1 * time.Hour)
+}
+
+type repeatableJob struct {
+	testJob
+	Repeated int
+}
+
+func (r *repeatableJob) Repeat() bool {
+	if r.Repeated == 2 {
+		return false
+	}
+	r.Repeated += 1
+
+	return true
+}
+
 func TestInit(t *testing.T) {
 	assert := assert.New(t)
 
-	t.Run("when run with some workers succeed", func(t *testing.T) {
-		jobs, quit := Init(1)
+	t.Run("when Init succeed and initializing thrall", func(t *testing.T) {
+		queue, close := Init(1)
 
-		assert.NotNil(jobs)
-		assert.NotNil(quit)
+		assert.NotNil(queue)
+		assert.NotNil(close)
+		assert.Len(wp.workers, 1)
+		assert.Equal(wp.Queue, queue)
+		assert.Equal(wp.close, close)
 
-		quit <- true
+		close <- true
+	})
+}
+
+func TestSchedule(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("when schedule succeed at scheduling a job", func(t *testing.T) {
+		queue, close := Init(1)
+
+		queue <- &scheduleableJob{}
+		time.Sleep(10 * time.Millisecond)
+
+		assert.Len(wp.Delayed, 1)
+
+		close <- true
 	})
 }

--- a/thrall/worker_test.go
+++ b/thrall/worker_test.go
@@ -2,53 +2,67 @@ package thrall
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
-
-type testJob struct {
-	Executed bool
-}
-
-func (tj *testJob) Run() error {
-	tj.Executed = true
-	return nil
-}
 
 func TestWorkerEnqueue(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("when there is no limiters", func(t *testing.T) {
 		t.Run("enqueue succeed adding the Job", func(t *testing.T) {
-			jobs, quit := Init(1)
+			queue, close := Init(1)
 
 			var job testJob
-			jobs <- &job
-			quit <- true
+			queue <- &job
+			time.Sleep(10 * time.Millisecond)
 
 			assert.True(job.Executed)
+
+			close <- true
 		})
 	})
 
 	t.Run("when there is limiters", func(t *testing.T) {
 		t.Run("enqueue succeed if limit is not reached", func(t *testing.T) {
-			jobs, quit := Init(1, WithMaxLimiter(1))
+			queue, close := Init(1, WithMaxLimiter(1))
 
 			var job testJob
-			jobs <- &job
-			quit <- true
+			queue <- &job
+			time.Sleep(10 * time.Millisecond)
 
 			assert.True(job.Executed)
+
+			close <- true
 		})
 
 		t.Run("enqueue fails if limit is reached", func(t *testing.T) {
-			jobs, quit := Init(1, WithMaxLimiter(0))
+			queue, close := Init(1, WithMaxLimiter(0))
 
 			var job testJob
-			jobs <- &job
-			quit <- true
+			queue <- &job
+			time.Sleep(10 * time.Millisecond)
 
 			assert.False(job.Executed)
+
+			close <- true
 		})
+	})
+}
+func TestWorkerRun(t *testing.T) {
+	assert := assert.New(t)
+
+	t.Run("when a Repeatable Job succeed on getting repeated", func(t *testing.T) {
+		queue, close := Init(1)
+
+		var job repeatableJob
+		queue <- &job
+		time.Sleep(10 * time.Millisecond)
+
+		assert.True(job.Executed)
+		assert.Equal(2, job.Repeated)
+
+		close <- true
 	})
 }


### PR DESCRIPTION
This PR adds the Scheduleable and Repeatable job interfaces / features, Scheduleable provides the feature of running delayed jobs, and Repeatable provides the feature of executing a job more than
once, both might be used together, so they provide the opportunity for endless ticking jobs that was it's original purpose.