### PR TITLE
Add error reporting throught channeling errors

### DIFF
--- a/worker_test.go
+++ b/worker_test.go
@@ -12,7 +12,7 @@ func TestWorkerEnqueue(t *testing.T) {
 
 	t.Run("when there is no limiters", func(t *testing.T) {
 		t.Run("enqueue succeed adding the Job", func(t *testing.T) {
-			queue, close := Init(1)
+			queue, _, close := Init(1)
 
 			var job testJob
 			queue <- &job
@@ -26,7 +26,7 @@ func TestWorkerEnqueue(t *testing.T) {
 
 	t.Run("when there is limiters", func(t *testing.T) {
 		t.Run("enqueue succeed if limit is not reached", func(t *testing.T) {
-			queue, close := Init(1, WithMaxLimiter(1))
+			queue, _, close := Init(1, WithMaxLimiter(1))
 
 			var job testJob
 			queue <- &job
@@ -38,7 +38,7 @@ func TestWorkerEnqueue(t *testing.T) {
 		})
 
 		t.Run("enqueue fails if limit is reached", func(t *testing.T) {
-			queue, close := Init(1, WithMaxLimiter(0))
+			queue, _, close := Init(1, WithMaxLimiter(0))
 
 			var job testJob
 			queue <- &job
@@ -54,7 +54,7 @@ func TestWorkerRun(t *testing.T) {
 	assert := assert.New(t)
 
 	t.Run("when a Repeatable Job succeed on getting repeated", func(t *testing.T) {
-		queue, close := Init(1)
+		queue, _, close := Init(1)
 
 		var job repeatableJob
 		queue <- &job
@@ -63,6 +63,19 @@ func TestWorkerRun(t *testing.T) {
 		assert.True(job.Executed)
 		assert.Equal(2, job.Repeated)
 
+		close <- true
+	})
+
+	t.Run("When a job fails the error is returned properly", func(t *testing.T) {
+		queue, errors, close := Init(1)
+
+		queue <- &errorJob{}
+		select {
+		case err := <-errors:
+			assert.Equal("job error on worker 1. Err: error!", err.Error())
+		case <-time.After(100 * time.Millisecond):
+			t.Error("Timeout waiting for the job to return an error")
+		}
 		close <- true
 	})
 }


### PR DESCRIPTION
This PR adds error reporting to thrall, the goal is ot enable the caller program to react to Job erros, 

Through channels this PR allow errors occurred on the Jobs to return to the caller as the Init() function would return a global error channel.